### PR TITLE
Fix tokenizer handling and QA file listing

### DIFF
--- a/backend/src/api/__init__.py
+++ b/backend/src/api/__init__.py
@@ -195,8 +195,14 @@ def stop_crawl(task_id):
 def calculate_tokens():
     """计算 Token 数量"""
     try:
-        data = request.json
-        repository_name = data.get('repository_name')
+        # 兼容直接传递字符串或JSON对象
+        data = request.get_json(silent=True)
+        if isinstance(data, dict):
+            repository_name = data.get('repository_name') or data.get('name')
+        elif isinstance(data, str):
+            repository_name = data
+        else:
+            repository_name = request.data.decode('utf-8').strip() if request.data else None
         
         # 验证参数
         if not repository_name:
@@ -226,9 +232,15 @@ def calculate_tokens():
 def generate_summary():
     """生成内容总结"""
     try:
-        data = request.json
-        repository_name = data.get('repository_name')
-        llm_config = data.get('llm_config')
+        data = request.get_json(silent=True)
+        llm_config = None
+        if isinstance(data, dict):
+            repository_name = data.get('repository_name') or data.get('name')
+            llm_config = data.get('llm_config')
+        elif isinstance(data, str):
+            repository_name = data
+        else:
+            repository_name = request.data.decode('utf-8').strip() if request.data else None
         
         # 验证参数
         if not repository_name:
@@ -257,9 +269,15 @@ def generate_summary():
 def generate_qa():
     """生成问答对"""
     try:
-        data = request.json
-        repository_name = data.get('repository_name')
-        llm_config = data.get('llm_config')
+        data = request.get_json(silent=True)
+        llm_config = None
+        if isinstance(data, dict):
+            repository_name = data.get('repository_name') or data.get('name')
+            llm_config = data.get('llm_config')
+        elif isinstance(data, str):
+            repository_name = data
+        else:
+            repository_name = request.data.decode('utf-8').strip() if request.data else None
         
         # 验证参数
         if not repository_name:
@@ -570,6 +588,26 @@ def import_repository_to_ragflow(name):
     
     except Exception as e:
         logging.error(f"导入信息库到RAGFlow失败: {str(e)}")
+        error_logs.add_error_log('ragflow', str(e), name)
+        return jsonify({'success': False, 'error': str(e)}), 500
+
+@api_blueprint.route('/ragflow/sync/<name>', methods=['POST'])
+def sync_repository_with_ragflow(name):
+    """同步信息库到RAGFlow"""
+    try:
+        repository = repository_manager.get_repository(name)
+        if not repository:
+            return jsonify({'success': False, 'error': f"信息库不存在: {name}"}), 404
+
+        result = ragflow_manager.sync_repository(name, repository)
+
+        return jsonify({
+            'success': True,
+            'result': result
+        })
+
+    except Exception as e:
+        logging.error(f"同步信息库到RAGFlow失败: {str(e)}")
         error_logs.add_error_log('ragflow', str(e), name)
         return jsonify({'success': False, 'error': str(e)}), 500
 

--- a/backend/src/repository/repository_manager.py
+++ b/backend/src/repository/repository_manager.py
@@ -362,11 +362,13 @@ def get_repository_files(name, file_types=None, include_summarized=True, include
                     continue
                 
                 # 获取文件信息
+                modified_time = datetime.fromtimestamp(os.path.getmtime(file_path)).isoformat()
                 file_info = {
                     'name': file_name,
                     'path': file_path,
                     'size': os.path.getsize(file_path),
-                    'modified': datetime.fromtimestamp(os.path.getmtime(file_path)).isoformat(),
+                    'modified': modified_time,
+                    'modified_time': modified_time,
                     'type': ext.lower()[1:]  # 去掉点号
                 }
                 
@@ -387,26 +389,38 @@ def get_repository_summary_files(name):
     if name not in repositories:
         raise ValueError(f"信息库不存在: {name}")
     
-    # 获取信息库目录
-    repository_dir = os.path.join(os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))), 
-                                 'data', 'crawled_data', name)
-    
-    # 获取文件列表
+    # 原始信息库目录
+    repository_dir = os.path.join(
+        os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))),
+        'data', 'crawled_data', name
+    )
+
+    # 预处理输出目录
+    output_dir = os.path.join(
+        os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))),
+        'data', config.get('summary_output_dir', 'summarizer_output'), name
+    )
+
+    search_dirs = [repository_dir, output_dir]
+
     files = []
-    for file_name in os.listdir(repository_dir):
-        if '_summarized.txt' in file_name:
-            file_path = os.path.join(repository_dir, file_name)
-            if os.path.isfile(file_path):
-                # 获取文件信息
-                file_info = {
-                    'name': file_name,
-                    'path': file_path,
-                    'size': os.path.getsize(file_path),
-                    'modified': datetime.fromtimestamp(os.path.getmtime(file_path)).isoformat(),
-                    'type': 'txt'
-                }
-                
-                files.append(file_info)
+    for d in search_dirs:
+        if not os.path.exists(d):
+            continue
+        for file_name in os.listdir(d):
+            if file_name.endswith('_summarized.txt'):
+                file_path = os.path.join(d, file_name)
+                if os.path.isfile(file_path):
+                    modified_time = datetime.fromtimestamp(os.path.getmtime(file_path)).isoformat()
+                    file_info = {
+                        'name': file_name,
+                        'path': file_path,
+                        'size': os.path.getsize(file_path),
+                        'modified': modified_time,
+                        'modified_time': modified_time,
+                        'type': 'txt'
+                    }
+                    files.append(file_info)
     
     return files
 
@@ -423,27 +437,37 @@ def get_repository_qa_files(name):
     if name not in repositories:
         raise ValueError(f"信息库不存在: {name}")
     
-    # 获取信息库目录
-    repository_dir = os.path.join(os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))), 
-                                 'data', 'crawled_data', name)
-    
-    # 获取文件列表
+    repository_dir = os.path.join(
+        os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))),
+        'data', 'crawled_data', name
+    )
+
+    output_dir = os.path.join(
+        os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))),
+        'data', config.get('qa_output_dir', 'qa_generator_output'), name
+    )
+
+    search_dirs = [repository_dir, output_dir]
+
     files = []
-    for file_name in os.listdir(repository_dir):
-        if '_qa_csv.csv' in file_name or '_qa_json.json' in file_name:
-            file_path = os.path.join(repository_dir, file_name)
-            if os.path.isfile(file_path):
-                # 获取文件信息
-                _, ext = os.path.splitext(file_name)
-                file_info = {
-                    'name': file_name,
-                    'path': file_path,
-                    'size': os.path.getsize(file_path),
-                    'modified': datetime.fromtimestamp(os.path.getmtime(file_path)).isoformat(),
-                    'type': ext.lower()[1:]  # 去掉点号
-                }
-                
-                files.append(file_info)
+    for d in search_dirs:
+        if not os.path.exists(d):
+            continue
+        for file_name in os.listdir(d):
+            if file_name.endswith('_qa.json') or file_name.endswith('_qa.csv') or '_qa_csv.csv' in file_name or '_qa_json.json' in file_name:
+                file_path = os.path.join(d, file_name)
+                if os.path.isfile(file_path):
+                    _, ext = os.path.splitext(file_name)
+                    modified_time = datetime.fromtimestamp(os.path.getmtime(file_path)).isoformat()
+                    file_info = {
+                        'name': file_name,
+                        'path': file_path,
+                        'size': os.path.getsize(file_path),
+                        'modified': modified_time,
+                        'modified_time': modified_time,
+                        'type': ext.lower()[1:]
+                    }
+                    files.append(file_info)
     
     return files
 

--- a/backend/src/utils/token_utils.py
+++ b/backend/src/utils/token_utils.py
@@ -8,45 +8,71 @@ Token工具模块
 """
 
 import logging
-import tiktoken
+from functools import lru_cache
 
-def count_tokens(text, model="gpt-3.5-turbo"):
+import tiktoken
+from transformers import AutoTokenizer
+
+
+@lru_cache(maxsize=None)
+def get_tokenizer(model: str = "gpt-3.5-turbo"):
+    """Return a tokenizer instance for the given model name.
+
+    The function falls back to ``cl100k_base`` encoding if a specialised
+    tokenizer cannot be loaded. HuggingFace models are loaded lazily and
+    any failures will be logged and ignored.
     """
-    计算文本的Token数量
-    
-    Args:
-        text: 文本内容
-        model: 模型名称，用于选择合适的tokenizer
-        
-    Returns:
-        token_count: Token数量
+    if not model:
+        model = "gpt-3.5-turbo"
+
+    name = model.lower()
+
+    try:
+        if name.startswith("gpt-4") or name.startswith("gpt-3.5"):
+            # All current OpenAI ChatGPT models use cl100k_base
+            return tiktoken.get_encoding("cl100k_base")
+        if "deepseek" in name:
+            try:
+                return AutoTokenizer.from_pretrained(
+                    "deepseek-ai/deepseek-llm-7b-base",
+                    trust_remote_code=True,
+                    use_fast=True,
+                )
+            except Exception as e:  # pragma: no cover - network in tests
+                logging.error(f"加载 DeepSeek tokenizer 失败: {e}")
+                return tiktoken.get_encoding("cl100k_base")
+        if "jina" in name:
+            try:
+                return AutoTokenizer.from_pretrained(
+                    "xlm-roberta-base",
+                    use_fast=True,
+                )
+            except Exception as e:  # pragma: no cover - network in tests
+                logging.error(f"加载 Jina tokenizer 失败: {e}")
+                return tiktoken.get_encoding("cl100k_base")
+    except Exception as e:
+        logging.error(f"获取 tokenizer 失败: {e}")
+
+    return tiktoken.get_encoding("cl100k_base")
+
+def count_tokens(text, tokenizer_or_model="gpt-3.5-turbo"):
+    """Return the number of tokens in ``text``.
+
+    ``tokenizer_or_model`` can be either a model name or a tokenizer/encoding
+    instance returned by :func:`get_tokenizer`.
     """
     if not text:
         return 0
-    
+
+    # Determine tokenizer
+    if isinstance(tokenizer_or_model, str):
+        tokenizer = get_tokenizer(tokenizer_or_model)
+    else:
+        tokenizer = tokenizer_or_model
+
     try:
-        # 根据模型选择合适的编码器
-        if model.startswith("gpt-4"):
-            encoding = tiktoken.encoding_for_model("gpt-4")
-        elif model.startswith("gpt-3.5"):
-            encoding = tiktoken.encoding_for_model("gpt-3.5-turbo")
-        elif "qwen" in model.lower():
-            encoding = tiktoken.encoding_for_model("cl100k_base")  # Qwen使用类似的编码
-        elif "deepseek" in model.lower():
-            encoding = tiktoken.encoding_for_model("cl100k_base")  # DeepSeek使用类似的编码
-        elif "gemini" in model.lower():
-            encoding = tiktoken.encoding_for_model("cl100k_base")  # Gemini使用类似的编码
-        elif "mistral" in model.lower():
-            encoding = tiktoken.encoding_for_model("cl100k_base")  # Mistral使用类似的编码
-        else:
-            # 默认使用cl100k_base编码
-            encoding = tiktoken.get_encoding("cl100k_base")
-        
-        # 计算Token数量
-        tokens = encoding.encode(text)
+        tokens = tokenizer.encode(text)
         return len(tokens)
-    
-    except Exception as e:
-        logging.error(f"计算Token失败: {str(e)}")
-        # 备用方案：简单估算
-        return len(text.split()) * 1.3  # 粗略估计：单词数 * 1.3
+    except Exception as e:  # pragma: no cover - fallback
+        logging.error(f"计算Token失败: {e}")
+        return int(len(text.split()) * 1.3)


### PR DESCRIPTION
## Summary
- add a cached `get_tokenizer` helper that falls back to `cl100k_base`
- update `count_tokens` to accept either a tokenizer or model name
- search summarizer/QA output folders when listing repository files

## Testing
- `npm test -- -w=off` *(fails: package.json missing)*
- `pytest` *(fails: command not found)*