### PR TITLE
Fix repo file listing and tokenizer utilities

### DIFF
--- a/backend/src/api/__init__.py
+++ b/backend/src/api/__init__.py
@@ -195,8 +195,14 @@ def stop_crawl(task_id):
 def calculate_tokens():
     """计算 Token 数量"""
     try:
-        data = request.json
-        repository_name = data.get('repository_name')
+        # 兼容直接传递字符串或JSON对象
+        data = request.get_json(silent=True)
+        if isinstance(data, dict):
+            repository_name = data.get('repository_name') or data.get('name')
+        elif isinstance(data, str):
+            repository_name = data
+        else:
+            repository_name = request.data.decode('utf-8').strip() if request.data else None
         
         # 验证参数
         if not repository_name:
@@ -226,9 +232,15 @@ def calculate_tokens():
 def generate_summary():
     """生成内容总结"""
     try:
-        data = request.json
-        repository_name = data.get('repository_name')
-        llm_config = data.get('llm_config')
+        data = request.get_json(silent=True)
+        llm_config = None
+        if isinstance(data, dict):
+            repository_name = data.get('repository_name') or data.get('name')
+            llm_config = data.get('llm_config')
+        elif isinstance(data, str):
+            repository_name = data
+        else:
+            repository_name = request.data.decode('utf-8').strip() if request.data else None
         
         # 验证参数
         if not repository_name:
@@ -257,9 +269,15 @@ def generate_summary():
 def generate_qa():
     """生成问答对"""
     try:
-        data = request.json
-        repository_name = data.get('repository_name')
-        llm_config = data.get('llm_config')
+        data = request.get_json(silent=True)
+        llm_config = None
+        if isinstance(data, dict):
+            repository_name = data.get('repository_name') or data.get('name')
+            llm_config = data.get('llm_config')
+        elif isinstance(data, str):
+            repository_name = data
+        else:
+            repository_name = request.data.decode('utf-8').strip() if request.data else None
         
         # 验证参数
         if not repository_name:
@@ -570,6 +588,26 @@ def import_repository_to_ragflow(name):
     
     except Exception as e:
         logging.error(f"导入信息库到RAGFlow失败: {str(e)}")
+        error_logs.add_error_log('ragflow', str(e), name)
+        return jsonify({'success': False, 'error': str(e)}), 500
+
+@api_blueprint.route('/ragflow/sync/<name>', methods=['POST'])
+def sync_repository_with_ragflow(name):
+    """同步信息库到RAGFlow"""
+    try:
+        repository = repository_manager.get_repository(name)
+        if not repository:
+            return jsonify({'success': False, 'error': f"信息库不存在: {name}"}), 404
+
+        result = ragflow_manager.sync_repository(name, repository)
+
+        return jsonify({
+            'success': True,
+            'result': result
+        })
+
+    except Exception as e:
+        logging.error(f"同步信息库到RAGFlow失败: {str(e)}")
         error_logs.add_error_log('ragflow', str(e), name)
         return jsonify({'success': False, 'error': str(e)}), 500
 

--- a/backend/src/repository/repository_manager.py
+++ b/backend/src/repository/repository_manager.py
@@ -362,11 +362,13 @@ def get_repository_files(name, file_types=None, include_summarized=True, include
                     continue
                 
                 # 获取文件信息
+                modified_time = datetime.fromtimestamp(os.path.getmtime(file_path)).isoformat()
                 file_info = {
                     'name': file_name,
                     'path': file_path,
                     'size': os.path.getsize(file_path),
-                    'modified': datetime.fromtimestamp(os.path.getmtime(file_path)).isoformat(),
+                    'modified': modified_time,
+                    'modified_time': modified_time,
                     'type': ext.lower()[1:]  # 去掉点号
                 }
                 
@@ -387,26 +389,29 @@ def get_repository_summary_files(name):
     if name not in repositories:
         raise ValueError(f"信息库不存在: {name}")
     
-    # 获取信息库目录
-    repository_dir = os.path.join(os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))), 
-                                 'data', 'crawled_data', name)
-    
-    # 获取文件列表
+    # 可能的目录
+    base_dir = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+    repository_dir = os.path.join(base_dir, 'data', 'crawled_data', name)
+    summary_dir = os.path.join(base_dir, 'data', 'summarizer_output', name)
+
     files = []
-    for file_name in os.listdir(repository_dir):
-        if '_summarized.txt' in file_name:
-            file_path = os.path.join(repository_dir, file_name)
-            if os.path.isfile(file_path):
-                # 获取文件信息
-                file_info = {
-                    'name': file_name,
-                    'path': file_path,
-                    'size': os.path.getsize(file_path),
-                    'modified': datetime.fromtimestamp(os.path.getmtime(file_path)).isoformat(),
-                    'type': 'txt'
-                }
-                
-                files.append(file_info)
+    for directory in [repository_dir, summary_dir]:
+        if not os.path.isdir(directory):
+            continue
+        for file_name in os.listdir(directory):
+            if '_summarized.txt' in file_name or file_name.endswith('_summary.txt'):
+                file_path = os.path.join(directory, file_name)
+                if os.path.isfile(file_path):
+                    modified_time = datetime.fromtimestamp(os.path.getmtime(file_path)).isoformat()
+                    file_info = {
+                        'name': file_name,
+                        'path': file_path,
+                        'size': os.path.getsize(file_path),
+                        'modified': modified_time,
+                        'modified_time': modified_time,
+                        'type': 'txt'
+                    }
+                    files.append(file_info)
     
     return files
 
@@ -423,27 +428,29 @@ def get_repository_qa_files(name):
     if name not in repositories:
         raise ValueError(f"信息库不存在: {name}")
     
-    # 获取信息库目录
-    repository_dir = os.path.join(os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))), 
-                                 'data', 'crawled_data', name)
-    
-    # 获取文件列表
+    base_dir = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+    repository_dir = os.path.join(base_dir, 'data', 'crawled_data', name)
+    qa_dir = os.path.join(base_dir, 'data', 'qa_generator_output', name)
+
     files = []
-    for file_name in os.listdir(repository_dir):
-        if '_qa_csv.csv' in file_name or '_qa_json.json' in file_name:
-            file_path = os.path.join(repository_dir, file_name)
-            if os.path.isfile(file_path):
-                # 获取文件信息
-                _, ext = os.path.splitext(file_name)
-                file_info = {
-                    'name': file_name,
-                    'path': file_path,
-                    'size': os.path.getsize(file_path),
-                    'modified': datetime.fromtimestamp(os.path.getmtime(file_path)).isoformat(),
-                    'type': ext.lower()[1:]  # 去掉点号
-                }
-                
-                files.append(file_info)
+    for directory in [repository_dir, qa_dir]:
+        if not os.path.isdir(directory):
+            continue
+        for file_name in os.listdir(directory):
+            if '_qa_' in file_name or file_name.endswith('_qa.json') or file_name.endswith('_qa.csv'):
+                file_path = os.path.join(directory, file_name)
+                if os.path.isfile(file_path):
+                    _, ext = os.path.splitext(file_name)
+                    modified_time = datetime.fromtimestamp(os.path.getmtime(file_path)).isoformat()
+                    file_info = {
+                        'name': file_name,
+                        'path': file_path,
+                        'size': os.path.getsize(file_path),
+                        'modified': modified_time,
+                        'modified_time': modified_time,
+                        'type': ext.lower()[1:]
+                    }
+                    files.append(file_info)
     
     return files
 

--- a/backend/src/utils/file_utils.py
+++ b/backend/src/utils/file_utils.py
@@ -50,6 +50,11 @@ def list_files(directory, extensions=None, name_filter=None):
     
     return files
 
+
+def read_file(file_path):
+    """Wrapper to read file content."""
+    return read_file_content(file_path)
+
 def read_file_content(file_path):
     """
     读取文件内容，支持txt、pdf、html格式

--- a/backend/src/utils/token_utils.py
+++ b/backend/src/utils/token_utils.py
@@ -8,45 +8,58 @@ Token工具模块
 """
 
 import logging
-import tiktoken
+from functools import lru_cache
 
-def count_tokens(text, model="gpt-3.5-turbo"):
-    """
-    计算文本的Token数量
-    
-    Args:
-        text: 文本内容
-        model: 模型名称，用于选择合适的tokenizer
-        
-    Returns:
-        token_count: Token数量
+import tiktoken
+from transformers import AutoTokenizer
+
+
+@lru_cache(maxsize=None)
+def get_tokenizer(model: str = "gpt-3.5-turbo"):
+    """Return a tokenizer instance for the given model name."""
+    try:
+        m = model.lower()
+        if m.startswith("gpt-4") or m.startswith("gpt-3.5"):
+            return tiktoken.encoding_for_model(model)
+        if "gpt-4o" in m:
+            try:
+                return tiktoken.encoding_for_model("gpt-4o")
+            except Exception:
+                return tiktoken.get_encoding("cl100k_base")
+        if "deepseek" in m:
+            return AutoTokenizer.from_pretrained(
+                "deepseek-ai/deepseek-llm-7b-base",
+                trust_remote_code=True,
+                use_fast=True,
+            )
+        if "jina" in m:
+            return AutoTokenizer.from_pretrained("xlm-roberta-base", use_fast=True)
+    except Exception as e:
+        logging.error(f"获取tokenizer失败: {str(e)}")
+    # Fallback
+    return tiktoken.get_encoding("cl100k_base")
+
+def count_tokens(text, model_or_tokenizer="gpt-3.5-turbo"):
+    """Return the token count for the given text.
+
+    Parameters
+    ----------
+    text: str
+        Text to tokenize.
+    model_or_tokenizer: str or tokenizer
+        Either a model name or a tokenizer instance.
     """
     if not text:
         return 0
-    
+
     try:
-        # 根据模型选择合适的编码器
-        if model.startswith("gpt-4"):
-            encoding = tiktoken.encoding_for_model("gpt-4")
-        elif model.startswith("gpt-3.5"):
-            encoding = tiktoken.encoding_for_model("gpt-3.5-turbo")
-        elif "qwen" in model.lower():
-            encoding = tiktoken.encoding_for_model("cl100k_base")  # Qwen使用类似的编码
-        elif "deepseek" in model.lower():
-            encoding = tiktoken.encoding_for_model("cl100k_base")  # DeepSeek使用类似的编码
-        elif "gemini" in model.lower():
-            encoding = tiktoken.encoding_for_model("cl100k_base")  # Gemini使用类似的编码
-        elif "mistral" in model.lower():
-            encoding = tiktoken.encoding_for_model("cl100k_base")  # Mistral使用类似的编码
+        if hasattr(model_or_tokenizer, "encode"):
+            tokenizer = model_or_tokenizer
         else:
-            # 默认使用cl100k_base编码
-            encoding = tiktoken.get_encoding("cl100k_base")
-        
-        # 计算Token数量
-        tokens = encoding.encode(text)
+            tokenizer = get_tokenizer(str(model_or_tokenizer))
+
+        tokens = tokenizer.encode(text)
         return len(tokens)
-    
     except Exception as e:
         logging.error(f"计算Token失败: {str(e)}")
-        # 备用方案：简单估算
-        return len(text.split()) * 1.3  # 粗略估计：单词数 * 1.3
+        return int(len(text.split()) * 1.3)


### PR DESCRIPTION
## Summary
- add simple `read_file` wrapper in backend
- add cached `get_tokenizer` and update `count_tokens` to accept tokenizer or name
- search summarizer and QA output folders when listing repository files

## Testing
- `npm test -- -w=off` *(fails: react-scripts not found)*
- `pytest` *(fails: command not found)*